### PR TITLE
Fix glitch in blog grid

### DIFF
--- a/utils.jl
+++ b/utils.jl
@@ -92,6 +92,7 @@ function hfun_blog_post_redirects()
             write(dst, redirect(relpath * "/"))
         end
     end
+    return ""
 end
 
 function hfun_add_redirects()


### PR DESCRIPTION
The function `hfun_blog_post_redirects` returned `nothing` which meant that in `news/index.md` the call

```
{{blogposts}}

{{blog_post_redirects}}
```

included the grid first then a literal `nothing`. 

To fix this, `hfun_blog_posts_redirects` now returns an empty string (basically all `hfun` should always return a string empty or not). 

closes #44 