### PR TITLE
Broken link in documentation.md

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -10,7 +10,7 @@ users interested in the functionality.
 
 ## SciML-Wide Documentation
 
-- [The SciML Common Interface](https://devdocs.sciml.ai/latest/)
+- [The SciML Common Interface](https://scimlbase.sciml.ai/dev/)
 - [SciMLTutorials](https://github.com/SciML/SciMLTutorials.jl)
 - [SciMLBenchmarks](https://github.com/SciML/SciMLBenchmarks.jl)
 

--- a/documentation.md
+++ b/documentation.md
@@ -10,7 +10,7 @@ users interested in the functionality.
 
 ## SciML-Wide Documentation
 
-- [The SciML Common Interface](https://scimlbase.sciml.ai/latest/)
+- [The SciML Common Interface](https://devdocs.sciml.ai/latest/)
 - [SciMLTutorials](https://github.com/SciML/SciMLTutorials.jl)
 - [SciMLBenchmarks](https://github.com/SciML/SciMLBenchmarks.jl)
 


### PR DESCRIPTION
I think I found the updated location, but let me know if the link should point somewhere else.