### PR TITLE
css width/code tweaks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"

--- a/_css/franklin.css
+++ b/_css/franklin.css
@@ -65,10 +65,13 @@ html {
 /* on wide screens, fix content width to a max value */
 @media (min-width: 940px) {
     .franklin-content {
-        /* width: 705px; */
+        width: 785px;
+        padding-left: 0%;
+        padding-right: 0%;
         margin-left: auto;
-        margin-right: auto; }
+        margin-right: auto; 
     }
+}
 
 /* on narrow device, reduce margins */
 @media (max-width: 480px) {
@@ -182,9 +185,11 @@ html {
 ================================================================== */
 
 .franklin-content img {
-    width: 70%;
+    width: 100%;
     text-align: center;
-    padding-left: 10%; }
+    padding-left: 3%;
+    padding-right: 3%;
+}
 
 .franklin-content .img-small img {
     width: 50%;
@@ -229,7 +234,11 @@ code {
 .hljs {
     font-size: 90%;
     line-height: 1.35em;
-    border-radius: 10px; }
+    border-radius: 10px; 
+    display: block;
+    overflow: auto;
+    padding: 0.5em 1em;
+}
 
 .hljs-meta, .hljs-metas, .hljs-metap { font-weight: bold; }
 


### PR DESCRIPTION
Minimal set of css enhancements to 
 1. On large screens fix to a smaller max width
 2. Set background color on entire box of code blocks, rather than just the text


Before (~1400 px wide)
![image](https://user-images.githubusercontent.com/1924092/193295083-43b6de7c-882e-46ef-97f0-99b3b34fdff0.png)

After (785 px wide)
![image](https://user-images.githubusercontent.com/1924092/193295175-b933b930-0c72-42e4-80ff-9477bacbe584.png)
