### PR TITLE
Make main page font easier to read

### DIFF
--- a/_css/styles.css
+++ b/_css/styles.css
@@ -489,7 +489,7 @@ progress {
 
 .lead {
   font-size: 1.25rem;
-  font-weight: 300;
+  font-weight: 400;
 }
 
 .display-1 {


### PR DESCRIPTION
This is a take-it-or-leave-it PR. 300 weight fonts are super difficult to read, even as someone with good eyesight and a generally high zoom rate. 

This PR just bumps up the font weight from 300 to 400 for the `lead` class on the splash page. Here's images showing the difference.

## Current
![300w](https://github.com/SciML/sciml.ai/assets/422990/81d6fdf8-8e24-4209-841d-650690b4f7ac)

## Proposed
![400w](https://github.com/SciML/sciml.ai/assets/422990/727fcf1b-44a8-4fa9-b30d-21f722292999)
