### PR TITLE
[Project declaration] ScimlOperators.jl with different defining vectors from actions

### DIFF
--- a/small_grants.md
+++ b/small_grants.md
@@ -165,6 +165,8 @@ Networks, and symbolic computing.
 
 ## Update SciMLOperators.jl to allow for different defining vectors from actions (\$500)
 
+**In Progress**: Claimed by Divyansh Goyal for the time period of March 5th - April 5th.
+
 SciMLOperators.jl is a package for defining lazy operators `A(u,p,t)*v` which can be used
 throughout the ecosystem. However, many of the operators incorrectly make the assumption
 that `u = v`, i.e. `A(u,p,t)*u` is the operation. While this is the only case required


### PR DESCRIPTION
Full name : Divyansh Goyal
CV : [divyansh_cv.pdf](https://github.com/user-attachments/files/19087531/divyansh_cv.pdf)

Contributor Info: Pertaining to the SciMLOperators.jl package, I have relevant working knowledge of  Linear Algebra through university courses and independent exploration with scripts involving multi-dimensional voxel data and performing native Julia operations over them. Further, under my contributions to the MedEye3d.jl, I implemented multiple dispatch for invoking reactive programming elements based on the input arguments. I am actively involved in the Juliahealth community, tracking insights across all juliahealth pkgs using Statistics. I am currently, nearing the end of my verbose documentation review of SciMLOperators.jl, and would love to embark on this project.

Project Description : SciMLOperators.jl is a package for defining lazy operators A(u,p,t)*v which can be used throughout the ecosystem. However, many of the operators incorrectly make the assumption that u = v, i.e. A(u,p,t)*u is the operation. While this is the only case required for some ODE integrators, this oversimplification limits the full usage of the library. It is expected that this is a breaking change (with a major release bump) and is the major change required for the v1.0 release. 