### PR TITLE
Add a navbar item for Commercial Support

### DIFF
--- a/_layout/header.html
+++ b/_layout/header.html
@@ -40,6 +40,11 @@
           </div>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="https://juliahub.com/company/contact-us-sciml">
+            Commercial Support
+          </a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="https://numfocus.org/donate-to-sciml"><i class="bi bi-heart"></i> Donate</a>
         </li>
       </ul>


### PR DESCRIPTION
Simple PR that adds a link to the SciML landing page specific contact form on [juliahub.com](https://info.juliahub.com).