### PR TITLE
Change Steering Council Members: Remove Vaibhav and add Aayush

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -25,7 +25,7 @@ handled on a case-by-case basis.
 
 ## Current Steering Council
 
-- [Vaibhav Dixit (Massachusetts Institute of Technology)](https://vaibhavdixit02.github.io/)
+- [Aayush Sabharwal (JuliaHub)](https://github.com/AayushSabharwal)
 - [Samuel Isaacson (Boston University)](http://math.bu.edu/people/isaacson/)
 - [Torkel Lohman (University of Oxford)](https://www.maths.ox.ac.uk/people/torkel.loman)
 - [Chris Rackauckas (Massachusetts Institute of Technology)](https://chrisrackauckas.com/)


### PR DESCRIPTION
Vaibhav had sent an email saying he was stepping down as his new full time position will not leave much time for open source. Aayush was nominated and approved by all 4 members. If Aayush approves then he will be a new steering council member.
