### PR TITLE
Improve training performance of GPU backend Project Extension

### DIFF
--- a/small_grants.md
+++ b/small_grants.md
@@ -552,7 +552,8 @@ in Julia.
 **Reviewers**: Chris Rackauckas
 
 ## Improve training performance of GPU backend in EvoTrees.jl (\$2000)
-**In Progress:** being worked on by Aditya Pandey from August 1st to September 1st, 2025."
+**In Progress:** being worked on by Aditya Pandey from August 1 to September 10, 2025.
+(Extended from September 1,2025 due to integration of work with main branch)
 
 EvoTrees.jl[https://github.com/Evovest/EvoTrees.jl] is an efficient pure-Julia 
 implementation of boosted trees. Performance on CPU is competitive and even superior to 

--- a/small_grants.md
+++ b/small_grants.md
@@ -552,8 +552,8 @@ in Julia.
 **Reviewers**: Chris Rackauckas
 
 ## Improve training performance of GPU backend in EvoTrees.jl (\$2000)
-**In Progress:** being worked on by Aditya Pandey from August 1 to September 10, 2025.
-(Extended from September 1,2025 due to integration of work with main branch)
+**In Progress:** being worked on by Aditya Pandey from August 1 to October 1, 2025.
+(Extended from September 1,2025 due to integration of work with main branch and adding features)
 
 EvoTrees.jl[https://github.com/Evovest/EvoTrees.jl] is an efficient pure-Julia 
 implementation of boosted trees. Performance on CPU is competitive and even superior to 


### PR DESCRIPTION
This PR requests for extension of Improve training performance of GPU backend Project under Small Grant Programme(https://sciml.ai/small_grants/#improve_training_performance_of_gpu_backend_in_evotreesjl_2000)

Reason:- During the project, I mistakenly took the `gpu-hist` branch as the base for development. While this branch allowed me to achieve notable training performance improvements achieving significant goals through this PR(https://github.com/Evovest/EvoTrees.jl/pull/294), it is outdated and suffers from slower CPU performance compared to main. To ensure we don't trade off CPU performance , the performance improvement code needs to be integrated into the `main `branch, along with adding some missing features.