### PR TITLE
v7 post: note the controller-kwarg fix is merged but not yet released

### DIFF
--- a/news/2026/07/28/OrdinaryDiffEqv7.md
+++ b/news/2026/07/28/OrdinaryDiffEqv7.md
@@ -19,7 +19,8 @@ you move on. The ones that matter are the handful where your code keeps running 
 means something else. There are three of those and they are what the first half of this post is about.
 
 Everything below was run against OrdinaryDiffEq v7.1.3, SciMLBase v3.39.1 and RecursiveArrayTools v4.3.4
-on Julia 1.11. The outputs are what those versions actually print, not what I remember them printing.
+on Julia 1.11, and re-checked against OrdinaryDiffEq v7.2.0 when that came out. The outputs are what
+those versions actually print, not what I remember them printing.
 
 ## The silent ones
 
@@ -153,10 +154,27 @@ using OrdinaryDiffEqCore: PIController
 solve(prob, alg; controller = PIController(0.7, -0.4))
 ```
 
-That `using OrdinaryDiffEqCore` is not a typo, incidentally; see the section on imports below. This is
-tracked as [OrdinaryDiffEq.jl#4027](https://github.com/SciML/OrdinaryDiffEq.jl/issues/4027) and the fix
-is to make these error properly, so at some point in the v7 series this section will become obsolete and
-you'll get a real error message instead. Until then it's on you to check.
+That `using OrdinaryDiffEqCore` is not a typo, incidentally; see the section on imports below.
+
+This was tracked as [OrdinaryDiffEq.jl#4027](https://github.com/SciML/OrdinaryDiffEq.jl/issues/4027) and
+it has since been fixed in [SciMLBase#1471](https://github.com/SciML/SciMLBase.jl/pull/1471). That takes
+all eight names back out of the accepted-keyword list. Once it ships you get a real error instead of
+silence, and the error points at the controller object instead of dumping the whole allowed-keyword list
+at you:
+
+```
+Unrecognized keyword arguments: [:gamma]
+
+These are step size controller options, which are no longer set as keyword arguments to
+`solve`. They are now fields of the controller object, passed via the `controller` keyword:
+...
+```
+
+The important caveat is that the fix is merged but **not yet released**. The newest SciMLBase in the
+General registry is v3.39.1, and re-running the `gamma` sweep above on today's releases (SciMLBase
+v3.39.1 with OrdinaryDiffEq v7.2.0) still gives 5597 steps for every value. So for the moment everything
+in this section stands and the grep is still on you. Once SciMLBase v3.40 lands you can stop worrying
+about it, because the solver will start complaining on your behalf.
 
 ## The loud ones
 


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Follow-up to #244, which merged today with a section that was written before https://github.com/SciML/SciMLBase.jl/pull/1471 landed on 2026-07-27.

### What changed

The controller-kwarg section said the fix was hypothetical ("the fix is to make these error properly, so at some point in the v7 series this section will become obsolete"). It now says the fix is merged, links the PR, and shows the error message users will get.

### What did *not* change, and why

I checked before rewriting: **the behavior the section documents is still exactly what users get today.** SciMLBase 3.40.0 exists only on master; the newest version in the General registry is still v3.39.1. Re-running the `gamma` sweep on a fresh install (SciMLBase v3.39.1, OrdinaryDiffEq **v7.2.0**, which is new since the post was written) still gives:

```
gamma=0.1   nsteps=5597
gamma=0.5   nsteps=5597
gamma=0.9   nsteps=5597
gamma=0.99  nsteps=5597
```

So the section heading and the whole diagnosis stand, and the "grep your solve calls" advice is still live. I only made the status explicit rather than rewriting it in the past tense, which would have been wrong for anyone installing today.

### Re-verified against OrdinaryDiffEq v7.2.0

Since 7.2.0 shipped after the post was written, I re-ran all 10 snippet groups against it rather than assuming a minor bump was safe. All pass: RAT v4 indexing, typed `autodiff`/`verbose`/`alias`, the sublibrary import for `KenCarp4`, `CheckInit` erroring with `BrownFullBasicInit` opting out, the simultaneous-event `VectorContinuousCallback` (both indices firing), seeded ensemble reproducibility, and the renamed tableau. The provenance line at the top now records the re-check.

### One thing worth your attention, unrelated to this PR

While checking whether 3.40.0 had been registered I found https://github.com/JuliaRegistries/General/pull/162635, open, capping 16 packages at SciMLBase 3.39. That is fallout from a *different* change in 3.40.0 which drops reexported names owned by SciMLOperators (`isconstant`, `islinear`, `issquare`, `has_adjoint`, `update_coefficients`, `MatrixOperator`, `ScalarOperator`) and ConstructionBase (`setproperties`) — not from #1471, which only touched the `allowedkeywords` tuple. Flagging it because it is presumably what is gating the 3.40 release, and therefore what gates this post's section becoming past tense.