### PR TITLE
Post-merge updates: prose pass on two posts, plus what shipped since they were written

### DIFF
--- a/news/2026/07/27/ModelingToolkitv11.md
+++ b/news/2026/07/27/ModelingToolkitv11.md
@@ -17,13 +17,14 @@ Major props to Aayush Sabharwal for leading much of the development on this rele
 With this, we have a lot to talk about and share. Some of this is a difficult discussion
 which we want to be transparent about, so please read through the entire post.
 
-A note on timing: ModelingToolkit v11.0.0 was tagged on December 11, 2025, and this post was
-drafted around that release. We held it while the community feedback threads on the
-[library split and licensing](https://discourse.julialang.org/t/modelingtoolkit-v11-library-split-and-licensing-community-feedback-requested/134396)
-ran their course. Rather than publish a stale announcement, we have updated it with what actually
-happened: at the time of writing, the series is at ModelingToolkit v11.36, ModelingToolkitBase v1.57,
-Symbolics v7.33, and SymbolicUtils v4.40. Where a plan described below changed in the intervening
-months, the text says so explicitly.
+One note on timing before we get into it. ModelingToolkit v11.0.0 was tagged on December 11, 2025, and
+most of this post was written around that release, but we held onto it while the community feedback
+threads on the [library split and
+licensing](https://discourse.julialang.org/t/modelingtoolkit-v11-library-split-and-licensing-community-feedback-requested/134396)
+ran their course. Publishing a seven month old announcement as though it were news seemed worse than
+publishing it with the benefit of hindsight, so the latter is what this is. The series is now at
+ModelingToolkit v11.36, ModelingToolkitBase v1.57, Symbolics v7.33 and SymbolicUtils v4.40, and wherever
+something described below turned out differently than we expected, the text says so.
 
 ## Licensing Changes
 
@@ -154,9 +155,9 @@ us to marry the [performance improvements of the advanced term representation](h
 with type-stability and all its associated performance benefits in SymbolicUtils.jl
 representation.
 
-The effect on time-to-first-X is not subtle. These are the first-call timings for the most common
-ModelingToolkit operations, measured before and after the change (full output in the
-[ModelingToolkit v11 release notes](https://github.com/SciML/ModelingToolkit.jl/blob/master/NEWS.md)):
+The effect on time-to-first-X is not subtle. Here are the first-call timings for the most common
+ModelingToolkit operations before and after the change, with the full `@time` output in the
+[v11 release notes](https://github.com/SciML/ModelingToolkit.jl/blob/master/NEWS.md):
 
 | Operation | Before | After | Speedup |
 |---|---|---|---|
@@ -165,13 +166,13 @@ ModelingToolkit operations, measured before and after the change (full output in
 | `TearingState` constructor | 0.374 s | 0.0021 s | ~180x |
 | `mtkcompile` (first call) | 1.773 s | 0.0186 s | ~95x |
 
-The "before" numbers are dominated by compilation (99%+ in each case, much of it *re*compilation).
-That is the tell: the old dynamic representation forced Julia to recompile the compiler pipeline in
-every fresh session, so none of it could be cached by precompilation. With the type-stable
-representation, that work moves into the package's precompile step and the first call is essentially
-just runtime. Your mileage will vary with the specific system, whether index reduction is required,
-whether array variables are involved, and what else is loaded in the session, but the shape of the
-improvement is consistent.
+What makes those "before" numbers what they are is that they're 99%+ compilation, and a good chunk of
+that is *re*compilation. The old dynamic representation meant Julia had to recompile the compiler
+pipeline itself in every fresh session, so essentially none of it could be cached by precompilation no
+matter how many `@compile_workload` blocks we threw at it. Now that work happens once, in the package's
+precompile step, and the first call is basically just runtime. The exact numbers will of course depend on
+the system, whether index reduction is needed, whether there are array variables involved, and what else
+you have loaded, but the shape of it holds up.
 
 Because the core aspects were now type-stable, changes were made to the parts on top of the representation,
 in particular the functions of Symbolics.jl and the compiler pipeline of ModelingToolkit.jl, to ensure that
@@ -186,9 +187,9 @@ There are still some functions being worked on to make them fully type-stable, f
 function still has some dynamic typing in it that increases the time-to-first-ODE-solve a bit. However, we believe
 that all of the required breaking changes have been made, and thus we wanted to get this version out there,
 and future minor version releases in the v11 time frame will continue to improve type-stability, performance,
-and time-to-first-X based on this new foundation. That has held: the 36 minor releases since v11.0 have been
-non-breaking, and a large fraction of them are exactly this kind of incremental type-stability and
-allocation work on top of the new foundation.
+and time-to-first-X based on this new foundation. Seven months later that has held up: there have been 36
+minor releases since v11.0, all of them non-breaking, and a good fraction of them are this sort of
+incremental type-stability and allocation work.
 
 Major props to Aayush Sabharwal for leading this effort.
 
@@ -220,15 +221,16 @@ for that. When completed, the generated code for array expressions will be O(1) 
 This will solve a long-standing issue in the ModelingToolkit compiler, and approximately 60% of the work is now
 completed because the Symbolics code generation was one major aspect.
 
-**Status update.** This is the part of the v11 plan that has moved slowest, so we want to be honest about
-where it stands rather than let the original text imply more than is true. As of ModelingToolkit v11.36,
-SymbolicCompilerPasses.jl is **not** enabled by default from the ModelingToolkit compiler — it remains
-opt-in. The Reactant.jl integration is likewise still pending on the upstream issue linked above, which
-is [still open](https://github.com/EnzymeAD/Reactant.jl/issues/1864). What *has* landed is steady work on the
-ModelingToolkit side of array handling: preserving arrays through flattened variable lookup, propagating
-array parameter assignments into SCC subsystems, and removing scalarization from observed-function
-codegen. So the foundation is real and being built on, but if you came here for O(1) array codegen turned
-on by default, that is still ahead of us rather than behind us.
+Of everything described in this post, this is the piece that has moved slowest since the release, and it
+would be misleading to leave the paragraph above sitting there without an update. As of ModelingToolkit
+v11.36, SymbolicCompilerPasses.jl is still not turned on by default from the ModelingToolkit compiler;
+it remains opt-in. The Reactant.jl integration is likewise still waiting on the upstream issue linked
+above, which is [open](https://github.com/EnzymeAD/Reactant.jl/issues/1864) at the time of writing. What
+has landed in the meantime is a steady stream of array handling work on the ModelingToolkit side:
+preserving arrays through flattened variable lookup, propagating array parameter assignments into SCC
+subsystems, dropping scalarization out of observed-function codegen. So the foundation is real and is
+being built on. But if you came here specifically for O(1) array codegen on by default, that is still
+ahead of us rather than behind us.
 
 We note for avid users that MethodOfLines.jl will need a substantial change in order to use array expressions
 in order for our PDE discretizers to benefit from these improvements, and NeuralPDE.jl's codegen will need a
@@ -238,28 +240,29 @@ new contributors to have an outsized impact.
 
 ## The ModelingToolkitStandardLibrary.jl: A Deprecation That We Called Off
 
-This section is the one that changed the most between drafting and publishing, and we think the honest
-thing to do is show both the original reasoning and what actually happened.
+This section changed more than any other between when it was drafted and when it was published. I could
+have silently rewritten it, but the difference between what we were going to say and what happened is
+instructive enough that it seems better to show both.
 
-**What we originally planned to announce:** that
-[ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl) would soon be deprecated,
-in favor of the Dyad standard libraries. The reasoning was that the library had fallen behind, nobody was
-actively maintaining it, and an alternative existed that subsumed its functionality.
+The plan was to announce that
+[ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl) would soon
+be deprecated in favor of the Dyad standard libraries, on the grounds that it had fallen behind, that
+nobody was actively maintaining it, and that an alternative existed which subsumed its functionality.
 
-**What actually happened:** the library got maintainers again. In the seven months since ModelingToolkit v11.0
-was tagged, ModelingToolkitStandardLibrary.jl has taken over 100 commits and a steady stream of releases,
-currently sitting at v2.29.5, with contributions from Fredrik Bagge Carlson, Aayush Sabharwal, Sebastian
-Micluța-Câmpeanu, and others. A large share of that work is exactly the kind of thing the deprecation
-notice was complaining about being absent: fixing rotational mechanics initialization and torque balance,
-repairing thermal and magnetic component tests, getting SISO initialization exercised through `ODEProblem`,
-and tracking the ModelingToolkit v11 compatibility floors. Meanwhile the Dyad component libraries we pointed
-at as the replacement have not seen a public push since mid-2025.
+Then the library got maintainers again. In the seven months since v11.0 was tagged it has taken over 100
+commits and a steady stream of releases, sitting at v2.29.5 as I write this, with work from Fredrik Bagge
+Carlson, Aayush Sabharwal, Sebastian Micluța-Câmpeanu and others. And it is not busywork: a large share
+of it is the sort of thing the deprecation notice was complaining about the absence of: fixing
+rotational mechanics initialization and torque balance, repairing thermal and magnetic component tests,
+getting SISO initialization exercised through `ODEProblem`, tracking the v11 compatibility floors.
+Meanwhile the Dyad component libraries we were going to point people at have not seen a public push
+since mid-2025.
 
-So: **the deprecation is called off.** ModelingToolkitStandardLibrary.jl is supported, and you should keep
-using it. We are leaving the original reasoning below because it is a fair description of the state the
-library was in at the end of 2025, and because it is a good illustration of how quickly "this is unmaintained"
-can be fixed by a couple of people deciding to maintain it. If you use this library, the maintainers would
-still welcome the help.
+So the deprecation is called off. ModelingToolkitStandardLibrary.jl is supported and you should keep
+using it. I have left the original reasoning below, partly because it was a fair description of where the
+library sat at the end of 2025, and partly because it is a nice demonstration of how fast "this is
+unmaintained" stops being true once two or three people decide otherwise. If you use this library, the
+maintainers would still be happy to have the help.
 
 ### The original reasoning (for the record)
 
@@ -285,23 +288,23 @@ libraries serve as a fully open source alternative to everything in the Modeling
 have lots of testing in the real world, and many thoughtful design decisions from some
 of the industry's best.
 
-That last paragraph is still true, and the Dyad component libraries remain an excellent BSD-3 option worth
-evaluating — in particular if you want components that trace back to the Modelica Standard Library's
-semantics. What is no longer true is the conclusion we drew from it. You now have two maintained choices
-rather than one deprecation, which is a better place to be. We do still owe better documentation and
-discoverability for purely ModelingToolkit / non-Dyad users of the Dyad component libraries.
+All of that is still accurate, and the Dyad component libraries are well worth evaluating on their own
+merits, particularly if you want components whose semantics trace back to the Modelica Standard Library.
+It was only the conclusion we drew that turned out to be wrong. Having two maintained options beats
+having one of them deprecated. We do still owe better documentation and discoverability for people who
+want to use the Dyad component libraries from plain ModelingToolkit without Dyad itself.
 
 ## Deprecation of the `@mtkmodel` Macro and Focusing the Development Effort of ModelingToolkit.jl as a Compiler
 
-The `@mtkmodel` macro is deprecated in ModelingToolkit v11, and unlike the standard library above, this one
-went through as planned — with the better of the two outcomes we described. It was not killed; it was
-spun out. `@mtkmodel` now lives in **SciCompDSL.jl** (MIT licensed, currently v1.0.1), which is developed in
-the ModelingToolkit monorepo under `lib/SciCompDSL`. It has been updated enough to build systems on v11, so
-existing `@mtkmodel` code keeps working — you add `SciCompDSL` to your project and `using SciCompDSL` instead
-of getting the macro from `ModelingToolkit`. It will not receive further maintenance from the core
-ModelingToolkit developers, but it is open to community contribution, and the spin-out means a new maintainer
-can take it over without needing commit rights to the compiler. The rest of this section is the reasoning
-behind that decision.
+Unlike the standard library above, this one went through as planned, and it got the better of the two
+outcomes we floated: `@mtkmodel` is deprecated out of ModelingToolkit v11, but it was spun out rather
+than killed. It now lives in SciCompDSL.jl, MIT licensed and currently at v1.0.1, developed in the
+ModelingToolkit monorepo under `lib/SciCompDSL`. It has had enough work to keep building systems on v11,
+so existing `@mtkmodel` code still runs. You add `SciCompDSL` to your project and `using SciCompDSL`
+instead of picking the macro up from `ModelingToolkit`. It won't get further maintenance from the core
+ModelingToolkit developers, but it is open to contribution, and having it as its own package means
+somebody can take it over without needing commit rights to the compiler. The rest of this section is why
+we went that way.
 
 The `@mtkmodel` macro was designed as a Modelica-like syntax for which one can use ModelingToolkit.jl. While
 some effort was put into it at the early stages, it ultimately has lacked much development for around the last
@@ -324,8 +327,8 @@ and stable numerical simulations.
 
 That does not mean that we do not like DSLs on ModelingToolkit, oh not at all! Instead this is making `@mtkmodel`
 no longer a privileged DSL of the project. For example, SymBoltz.jl and Catalyst.jl are two great DSLs built on
-ModelingToolkit.jl, just as separate packages. Spinning `@mtkmodel` out into SciCompDSL.jl puts it on exactly
-that footing. The open call for new folks to come in and own it still stands — and, as the standard library
+ModelingToolkit.jl, just as separate packages. Spinning `@mtkmodel` out into SciCompDSL.jl puts it on
+that same footing. The open call for new folks to come in and own it still stands, and as the standard library
 above shows, that call does sometimes get answered.
 
 We also must note that if someone really does need a fully developed DSL that is Modelica-like and compiles to

--- a/news/2026/07/28/OrdinaryDiffEqv7.md
+++ b/news/2026/07/28/OrdinaryDiffEqv7.md
@@ -141,29 +141,9 @@ Identical across a 10x range of `gamma`, where on v6 those four runs would have 
 `totally_bogus_kwarg` errored correctly, so this was specific to the controller names having been left in
 the allowlist after the code that consumed them was removed.
 
-SciMLBase v3.40 fixes this. On a current environment you get a real error that names the replacement
-instead of silence:
-
-```
-Unrecognized keyword arguments: [:gamma]
-
-These are step size controller options, which are no longer set as keyword arguments to
-`solve`. They are now fields of the controller object, passed via the `controller` keyword:
-
-    # old
-    solve(prob, alg; gamma = 0.9, beta1 = 0.7, beta2 = -0.4)
-
-    # new
-    using OrdinaryDiffEqCore: PIController
-    solve(prob, alg; controller = PIController(0.7, -0.4))
-```
-
-The reason this section is still here rather than deleted: if you are pinned to SciMLBase v3.39 or
-earlier, everything above still applies to you and nothing will warn you about it. Grep for those names
-in your `solve` calls before you conclude you're fine. On v3.40 and later the solver does the grepping
-for you.
-
-Either way the migration is the same, and it's to put them on the controller object:
+SciMLBase v3.40 removes them from the accepted list, so you get a real error instead. On v3.39 and
+earlier you don't, so grep for those names in your `solve` calls. Either way the migration is to put
+them on the controller object:
 
 ```julia
 # v6

--- a/news/2026/07/28/OrdinaryDiffEqv7.md
+++ b/news/2026/07/28/OrdinaryDiffEqv7.md
@@ -19,7 +19,8 @@ you move on. The ones that matter are the handful where your code keeps running 
 means something else. There are three of those and they are what the first half of this post is about.
 
 Everything below was run against OrdinaryDiffEq v7.1.3, SciMLBase v3.39.1 and RecursiveArrayTools v4.3.4
-on Julia 1.11. The outputs are what those versions actually print, not what I remember them printing.
+on Julia 1.11, and re-checked against OrdinaryDiffEq v7.2.0 and SciMLBase v3.40 when those landed. The
+outputs are what those versions actually print, not what I remember them printing.
 
 ## The silent ones
 
@@ -110,7 +111,7 @@ sol_old = RaggedVectorOfArray(sol)   # sol_old[i] is the i-th timestep again
 Treat it as a compatibility layer for unblocking a migration, though, not as something to write new code
 against.
 
-### Controller keyword arguments are accepted and then ignored
+### Controller keyword arguments were accepted and then ignored
 
 The adaptive step size controller got refactored from a pile of loose numeric knobs on `solve` into
 actual controller objects, so `gamma`, `beta1`, `beta2`, `qmin`, `qmax`, `qsteady_min`, `qsteady_max` and
@@ -118,8 +119,8 @@ actual controller objects, so `gamma`, `beta1`, `beta2`, `qmin`, `qmax`, `qstead
 a good change, and it's what makes it possible to write your own controller and pass
 `controller = MyController(…)` instead of us adding a fourteenth keyword argument to `solve`.
 
-The sharp edge is that in the released version those old keyword arguments are still on the accepted
-list, so passing them doesn't error. They just don't do anything:
+The sharp edge, on SciMLBase v3.39.1 and earlier, is that those old keyword arguments were still on the
+accepted list, so passing one didn't error. It just didn't do anything:
 
 ```julia
 for g in (0.1, 0.5, 0.9, 0.99)
@@ -136,13 +137,33 @@ gamma=0.99 nsteps=5597
 ```
 
 Identical across a 10x range of `gamma`, where on v6 those four runs would have differed substantially.
-`qmin`, `qmax`, `beta1`, `beta2` and `qoldinit` all behave the same way. A properly unknown keyword like
-`totally_bogus_kwarg` does still error, so this is specific to the controller names having been left in
+`qmin`, `qmax`, `beta1`, `beta2` and `qoldinit` all behaved the same way. A properly unknown keyword like
+`totally_bogus_kwarg` errored correctly, so this was specific to the controller names having been left in
 the allowlist after the code that consumed them was removed.
 
-If you tuned your controller, and people who tune their controller usually had a reason, your solver is
-now running on defaults and will not tell you. Grep for those names in your `solve` calls. The migration
-is to put them on the controller object:
+SciMLBase v3.40 fixes this. On a current environment you get a real error that names the replacement
+instead of silence:
+
+```
+Unrecognized keyword arguments: [:gamma]
+
+These are step size controller options, which are no longer set as keyword arguments to
+`solve`. They are now fields of the controller object, passed via the `controller` keyword:
+
+    # old
+    solve(prob, alg; gamma = 0.9, beta1 = 0.7, beta2 = -0.4)
+
+    # new
+    using OrdinaryDiffEqCore: PIController
+    solve(prob, alg; controller = PIController(0.7, -0.4))
+```
+
+The reason this section is still here rather than deleted: if you are pinned to SciMLBase v3.39 or
+earlier, everything above still applies to you and nothing will warn you about it. Grep for those names
+in your `solve` calls before you conclude you're fine. On v3.40 and later the solver does the grepping
+for you.
+
+Either way the migration is the same, and it's to put them on the controller object:
 
 ```julia
 # v6
@@ -153,10 +174,9 @@ using OrdinaryDiffEqCore: PIController
 solve(prob, alg; controller = PIController(0.7, -0.4))
 ```
 
-That `using OrdinaryDiffEqCore` is not a typo, incidentally; see the section on imports below. This is
-tracked as [OrdinaryDiffEq.jl#4027](https://github.com/SciML/OrdinaryDiffEq.jl/issues/4027) and the fix
-is to make these error properly, so at some point in the v7 series this section will become obsolete and
-you'll get a real error message instead. Until then it's on you to check.
+That `using OrdinaryDiffEqCore` is not a typo, incidentally; see the section on imports below. The whole
+thing was tracked as [OrdinaryDiffEq.jl#4027](https://github.com/SciML/OrdinaryDiffEq.jl/issues/4027) and
+fixed in [SciMLBase#1471](https://github.com/SciML/SciMLBase.jl/pull/1471).
 
 ## The loud ones
 

--- a/news/2026/07/29/sciml_since_ode_v7.md
+++ b/news/2026/07/29/sciml_since_ode_v7.md
@@ -6,35 +6,35 @@
 
 # What's New in SciML Since OrdinaryDiffEq v7
 
-OrdinaryDiffEq v7 and DifferentialEquations v8 shipped at the end of April 2026, and we
-[wrote up what breaks and how to migrate](https://sciml.ai/news/2026/07/28/OrdinaryDiffEqv7/). That post is
-about paying a cost. This one is about what the cost bought.
+OrdinaryDiffEq v7 and DifferentialEquations v8 shipped at the end of April, and last week we
+[wrote up what breaks and how to migrate](https://sciml.ai/news/2026/07/28/OrdinaryDiffEqv7/). That was
+a long list of things you have to go fix. That is a fair description of a breaking release, if not a
+very encouraging one. The reason we put everyone through it was to be able to build things that the old
+foundation could not support, so three months on, here is what got built.
 
-A breaking release is only worth it if it clears the way for things you could not do before. Three months
-on, here is what has actually been built on the new foundation. Everything below was run locally against
-the currently registered versions; where a feature is on `master` but not yet released, or not yet
-co-installable with something else, this post says so rather than letting you find out the hard way.
+Everything below was run locally against the currently registered versions. Where something is sitting on
+`master` but not tagged, or where a version bound gets between you and a feature, I've said so. Those are
+exactly the details a summary written from commit messages gets wrong, and you would find them out the
+hard way about ten minutes after reading this.
 
-## Homotopy continuation is now everywhere in the stack
+## Continuation methods, everywhere
 
-If there is one theme to the last three months, this is it. Continuation methods went from "not really a
-thing in SciML" to a first-class problem type with a solver family, and then propagated outward into the
-ODE solvers and into ModelingToolkit's initialization. This is the change most likely to fix a problem you
-currently have.
+If the last three months had a theme, this is it. Homotopy continuation went from something SciML didn't
+really do to a first-class problem type with a solver family behind it, and then started showing up
+underneath things you already call.
 
-The foundation is a new problem type in SciMLBase, `HomotopyProblem`, plus `HomotopyNonlinearFunction`.
-Rather than asking a Newton solver to jump straight to the answer from your initial guess, you describe a
-*path*: a family of problems `H(u, p, λ)` parameterized by `λ`, where `λ = 0` is something you can solve
-trivially and `λ = 1` is the problem you care about. The solver then tracks the solution along the path.
+The foundation is `HomotopyProblem` in SciMLBase, along with `HomotopyNonlinearFunction`. Instead of
+asking Newton to jump straight to the answer from whatever guess you had lying around, you describe a
+path: a family `H(u, p, λ)` where `λ = 0` is something trivially solvable and `λ = 1` is the problem you
+care about, and the solver tracks the solution along it. Newton's method is only locally convergent, and
+continuation is the standard answer to that. It's how you get global convergence from a bad guess, and
+more importantly it's how you handle a solution branch that folds back on itself. Parameter marching
+cannot do that however small you make the steps.
 
-Why this matters: Newton's method is only locally convergent. Continuation is how you get a *globally*
-convergent method when you have a bad initial guess, and it is how you handle problems where the solution
-branch folds back on itself — which plain parameter-marching fundamentally cannot do.
-
-Here is the fold case, which is the one worth seeing. Take `u³ - 3u = -3 + 6λ` on `λ ∈ [0, 1]`. It has
-turning points at `u = ±1`, i.e. `λ = 1/6` and `λ = 5/6`. To get from the `λ = 0` root on the lower sheet
-to the `λ = 1` root on the upper sheet along the *connected* branch, `λ` must rise to 5/6, **reverse**
-down to 1/6, and then climb to 1:
+The fold case is the one to look at. Take `u³ - 3u = -3 + 6λ` over `λ ∈ [0, 1]`. There are
+turning points at `u = ±1`, that is at `λ = 1/6` and `λ = 5/6`. Getting from the `λ = 0` root on the lower
+sheet to the `λ = 1` root on the upper sheet along the connected branch means `λ` has to climb to 5/6,
+reverse all the way back down to 1/6, and only then go up to 1:
 
 ```julia
 using NonlinearSolve, SciMLBase
@@ -51,229 +51,192 @@ u at λ=1        = 2.103803
 target residual = 1.78e-15
 ```
 
-`ArcLengthContinuation` implements pseudo-arclength continuation: it parameterizes by arclength along the
-solution curve instead of by `λ`, so reversing direction in `λ` is not a special case — it is just
-continuing to walk forward along the curve. Instrumenting the residual evaluations confirms the solver
-climbs past the first turning point and then reverses, exactly as the geometry requires. A
-natural-parameter method that only ever increases `λ` cannot do this; it walks off the end of the lower
-sheet at the fold and fails.
+`ArcLengthContinuation` parameterizes by arclength along the solution curve instead of by `λ`, so
+reversing direction needs no special handling. The solver just keeps walking forward along the curve.
+Instrumenting the residual evaluations confirms it climbs past the first turning point and then heads
+back down, exactly as the geometry demands. A natural-parameter method that only ever
+increases `λ` walks off the end of the lower sheet at the fold and fails.
 
-The continuation surface available today:
+Currently released, alongside `ArcLengthContinuation` (which also takes `predictor = :tangent` for a true
+tangent predictor): `HomotopyPolyAlgorithm`, a staged polyalgorithm that tries the cheap strategies before
+the expensive ones; `SimpleHomotopySweep`, an allocation-free version for StaticArrays and small systems
+in hot loops; and `PseudoTransient`, which picked up mass-matrix damping. Two more are on `master` and
+worth watching but not yet tagged: `TaylorHomotopyContinuationJL`, which polynomializes non-polynomial
+systems so the polynomial homotopy machinery applies to them, and `FastShortcutHomotopyPolyalg`, the
+autodiff-aware default.
 
-| Solver | What it is for |
-|---|---|
-| `ArcLengthContinuation` | Pseudo-arclength continuation; handles folds and turning points. `predictor = :tangent` gives a true tangent predictor. |
-| `HomotopyPolyAlgorithm` | Staged polyalgorithm for `HomotopyProblem` — tries cheap strategies before expensive ones |
-| `SimpleHomotopySweep` | Allocation-free continuation for `StaticArrays`, for small systems in hot loops |
-| `PseudoTransient` | Pseudo-transient continuation, now with mass-matrix damping |
+The part that matters for people who don't want to think about any of this is that continuation is being
+wired in as an implementation strategy underneath existing APIs. OrdinaryDiffEq now has
+`HomotopyNonlinearSolveAlg`, which solves the implicit stage equations of a stiff method by step-size
+homotopy continuation. When a Newton iteration inside an implicit solver fails the traditional response
+is to cut `dt` and try again, and this is a more principled version of the same instinct. It ships in
+`OrdinaryDiffEqNonlinearSolve` v2.4.0 and not the umbrella, so you want
+`using OrdinaryDiffEqNonlinearSolve: HomotopyNonlinearSolveAlg`. Meanwhile ModelingToolkit now routes DAE
+and ODE initialization through the continuation solver. The fit there is obvious once you say it out
+loud. Consistent initialization
+of a DAE is the problem of solving a hard nonlinear system from a guess that might be poor, and
+initialization failure has been one of the most common ways a large acausal model refuses to run at all.
 
-Two more sit on `master` and are worth watching but are not in a registered release as of writing:
-`TaylorHomotopyContinuationJL`, a polynomialization front-end that lets you apply polynomial homotopy
-machinery to *non*-polynomial systems, and `FastShortcutHomotopyPolyalg`, the named autodiff-aware default.
+So if you've ever stared at an "initialization failed" message on a big model, or watched a stiff solve
+die on Newton convergence, this is the work aimed squarely at you.
 
-### Where it shows up without you asking
+## Multirate integrators
 
-The part that matters for ordinary users is that continuation is being wired in as an *implementation*
-strategy underneath things you already call:
+`OrdinaryDiffEqMultirate` is a new sublibrary of multirate infinitesimal methods for split problems
+`du/dt = f₁(u,t) + f₂(u,t)` where `f₁` is fast and `f₂` is slow. The slow term is frozen across a macro
+step while the fast term gets `m` micro-steps, so the expensive slow right-hand side is evaluated once per
+macro step instead of once per micro-step.
 
-- **OrdinaryDiffEq** gained `HomotopyNonlinearSolveAlg`, which solves the implicit stage equations of a
-  stiff method by step-size homotopy continuation. When a Newton iteration inside an implicit solver
-  fails, the classic remedy is to cut `dt` and retry; continuation is a more principled version of the
-  same idea. It ships in `OrdinaryDiffEqNonlinearSolve` (v2.4.0), not the `OrdinaryDiffEq` umbrella, so
-  reach it with `using OrdinaryDiffEqNonlinearSolve: HomotopyNonlinearSolveAlg`.
-- **ModelingToolkit** now routes DAE and ODE initialization through the homotopy continuation solver.
-  Consistent initialization of a DAE is exactly the "solve a hard nonlinear system from a guess that may
-  be poor" problem that continuation is built for, and initialization failures have historically been one
-  of the most common ways a large acausal model refuses to run.
-
-If you have ever hit "initialization failed" on a big model, or watched a stiff solve die with a Newton
-convergence failure, this is the work aimed at you.
-
-## A multirate integrator family
-
-`OrdinaryDiffEqMultirate` is a new sublibrary implementing multirate infinitesimal methods for split
-problems `du/dt = f₁(u,t) + f₂(u,t)`, where `f₁` is fast and `f₂` is slow. The slow term is frozen across
-a macro step while the fast term is integrated with `m` micro-steps, so you evaluate the expensive slow
-right-hand side once per macro step instead of once per micro-step.
-
-Available today in `OrdinaryDiffEqMultirate` v2.6.0:
-
-| Method | Order | Kind |
-|---|---|---|
-| `MRIGARKERK22a`, `MRIGARKERK22b` | 2 | Explicit MRI-GARK (Sandu 2019) |
-| `MRIGARKERK33a` | 3 | Explicit MRI-GARK |
-| `MRIGARKERK45a` | 4 | Explicit MRI-GARK |
-| `MRIGARKIRK21a` | 2 | Solve-decoupled implicit MRI-GARK |
-| `MRIGARKESDIRK34a` | 3 | Solve-decoupled implicit MRI-GARK |
-| `MRAB` | — | Multirate Adams–Bashforth (k-step) |
-| `MREEF` | adaptive | Multirate Richardson extrapolation, Euler base |
-| `MIS` | — | Multirate infinitesimal step (Wensch–Knoth–Galant) |
-
-Usage is the standard `SplitODEProblem`, with `m` (the micro-step count) as a required keyword:
+What's in v2.6.0: `MRIGARKERK22a` and `MRIGARKERK22b` (order 2), `MRIGARKERK33a` (order 3) and
+`MRIGARKERK45a` (order 4) from the Sandu 2019 explicit MRI-GARK family; `MRIGARKIRK21a` and
+`MRIGARKESDIRK34a` for the solve-decoupled implicit versions; plus `MRAB` (multirate Adams–Bashforth),
+`MREEF` (Richardson extrapolation on an Euler base, adaptive) and `MIS` (Wensch–Knoth–Galant). It's a
+standard `SplitODEProblem`, with `m` as a required keyword:
 
 ```julia
 using OrdinaryDiffEqMultirate, SciMLBase
 
-f_fast!(du, u, p, t) = @. du = -50.0 * u     # fast
-f_slow!(du, u, p, t) = @. du = -u            # slow, and expensive in real problems
+f_fast!(du, u, p, t) = @. du = -50.0 * u
+f_slow!(du, u, p, t) = @. du = -u
 
 prob = SplitODEProblem(f_fast!, f_slow!, [1.0, 2.0, 3.0], (0.0, 1.0))
 sol  = solve(prob, MRIGARKERK33a(m = 10); dt = 0.01, adaptive = false)
 ```
 
-Verifying the order claim on that problem by halving `dt`:
+Halving `dt` on that problem confirms the order claim, giving observed orders of 3.31, 3.15 and 3.08 as
+the step size comes down, converging on 3 as advertised. Counting right-hand side calls at `dt = 0.01`
+with `m = 10` shows the structural property these methods exist for. `MRAB` does 1001 fast evaluations
+against 101 slow ones, `MRIGARKERK33a` does 9001 against 301, and `MRIGARKERK45a` does 20001 against 501.
+Somewhere between twenty and forty times fewer evaluations of the expensive half.
 
-```
-dt 0.02  -> 0.01     observed order = 3.31
-dt 0.01  -> 0.005    observed order = 3.15
-dt 0.005 -> 0.0025   observed order = 3.08
-```
-
-Converging at order 3, as advertised. And the structural property these methods exist for, measured by
-counting right-hand side calls at `dt = 0.01`, `m = 10`:
-
-| Method | fast RHS calls | slow RHS calls |
-|---|---|---|
-| `MRAB(m=10)` | 1001 | 101 |
-| `MRIGARKERK22a(m=10)` | 4001 | 201 |
-| `MRIGARKERK33a(m=10)` | 9001 | 301 |
-| `MRIGARKERK45a(m=10)` | 20001 | 501 |
-
-Roughly 20-40x fewer slow-term evaluations than fast-term evaluations.
-
-**An honest caveat, because it decides whether this helps you.** That call-count ratio is a structural
-property, not a speedup. Whether it becomes wall-clock time depends on two things being true: your slow
-term must be genuinely expensive relative to the fast term, *and* your macro step size must be limited by
-the slow dynamics rather than the fast ones. I tried to construct a synthetic benchmark showing a clean
-win over `Tsit5` on the combined right-hand side and could not — on a fast oscillation riding a slow
-decay, the macro step is still constrained by the need to resolve the oscillation, and single-rate `Tsit5`
-was competitive per unit of accuracy. These methods are aimed at problems like atmospheric dynamics, where
-the fast acoustic modes are cheap and local while the slow physics is expensive and global. If that is not
-your problem shape, measure before switching.
+Now the caveat, because it decides whether any of this helps you. That ratio is a structural property of
+the method, not a speedup. It turns into wall-clock time only if your slow term is expensive relative to
+the fast one *and* your macro step is limited by the slow dynamics instead of the fast ones.
+I tried to build a synthetic benchmark showing a clean win over `Tsit5` on the combined right-hand side
+and could not manage it: on a fast oscillation riding a slow decay the macro step stays pinned by the
+need to resolve the oscillation, and single-rate `Tsit5` was competitive per unit of accuracy. These
+methods are aimed at things like atmospheric dynamics, where the fast acoustic modes are cheap and local
+and the slow physics is expensive and global. If your problem doesn't have that shape, benchmark before
+switching.
 
 ## New solvers
 
-Verified present in the current registered sublibraries:
+`Rodas3d` in `OrdinaryDiffEqRosenbrock` v2.6.0 is an L-stable, stiffly accurate Rosenbrock method built
+for DAEs that are integrating toward a steady state. On the Robertson problem out to `t = 1e5` it agrees
+with `Rodas5P` to six significant figures and satisfies the algebraic constraint to `1.1e-16`, taking
+1109 steps against Rodas5P's 193, about what its lower order implies. If you integrate DAEs to steady
+state and the higher-order Rodas methods have given you trouble there, try it.
 
-- **`Rodas3d`** (`OrdinaryDiffEqRosenbrock` v2.6.0) — an L-stable, stiffly accurate Rosenbrock method
-  aimed specifically at DAE integration that approaches a steady state. On the Robertson DAE to `t = 1e5`
-  it lands on the same answer as `Rodas5P` to six significant figures and satisfies the algebraic
-  constraint to `1.1e-16`, taking more steps as its lower order implies. If you integrate DAEs to steady
-  state and have had trouble with the higher-order Rodas methods there, this is the one to try.
-- **`Rodas4PW`** (`OrdinaryDiffEqRosenbrock` v2.6.0) — a W-method variant of `Rodas4P`.
-- **`ARS222`, `ARS232`, `ARS343`, `ARS443`, `BHR553`** (`OrdinaryDiffEqSDIRK` v2.8.1) — IMEX Runge–Kutta
-  schemes (Ascher–Ruuth–Spiteri, and Boscarino–Russo's BHR(5,5,3)). Useful for convection–diffusion-shaped
-  problems where you want to treat one operator implicitly and the other explicitly.
-- **`ESDIRK325L2SA`** — the Kennedy–Carpenter (2019) ESDIRK3(2)5L[2]SA method, joining the existing
-  `ESDIRK436L2SA2` / `ESDIRK437L2SA` / `ESDIRK547L2SA2` / `ESDIRK54I8L2SA` / `ESDIRK659L2SA` family, plus a
-  generic stage-predictor menu for ESDIRK methods.
+Also newly available: `Rodas4PW`, a W-method variant of `Rodas4P`, in the same package. In
+`OrdinaryDiffEqSDIRK` v2.8.1 there's a batch of IMEX Runge–Kutta schemes: `ARS222`, `ARS232`, `ARS343`
+and `ARS443` from Ascher–Ruuth–Spiteri, plus Boscarino–Russo's `BHR553`. Those are the right shape for
+convection–diffusion problems where you want one operator implicit and the other explicit. And
+`ESDIRK325L2SA`, the Kennedy–Carpenter 2019 method, joins the existing `ESDIRK436L2SA2`,
+`ESDIRK437L2SA`, `ESDIRK547L2SA2`, `ESDIRK54I8L2SA` and `ESDIRK659L2SA` family. That family also picked
+up a generic stage-predictor menu.
 
-On `master` but not yet in a registered release: `MSRK10` (Stepanov order-10 explicit RK) and the
-Runge–Kutta–Gegenbauer stabilized methods.
+On `master` but not yet tagged: `MSRK10`, Stepanov's order-10 explicit RK, and the Runge–Kutta–Gegenbauer
+stabilized methods.
 
-## LinearSolve v5: a pure-Julia sparse LU, and eigenvalue problems
+## LinearSolve v5
 
-`SupernodalLUFactorization` is a pure-Julia supernodal LU (a Schenk–Gärtner-style algorithm via
-PurePardiso.jl). The interesting property is not raw speed — it is that it is *Julia*, with no SuiteSparse
-C dependency in the path, which matters for static compilation, trimming, and unusual element types.
+`SupernodalLUFactorization` is a pure-Julia supernodal LU, a Schenk–Gärtner-style algorithm via
+PurePardiso.jl. What makes it interesting is not raw speed but the absence of any SuiteSparse C
+dependency in the path. That matters if you are doing static compilation or trimming, and it
+matters if your element type is something the C libraries have never heard of.
 
-Measured on a 2D 5-point Laplacian, median of 3 runs after warmup:
+On a 2D five-point Laplacian, median of three runs after warmup, it's competitive. At n = 4,900 it takes
+0.019s against UMFPACK's 0.174s and KLU's 0.012s, and by n = 10,000 the three have converged to roughly
+0.047s, 0.049s and 0.039s respectively, with relative residuals around 1e-13 for all of them. That's why
+the structured-sparse default LU now routes to it. On an unstructured matrix with random fill I measured
+it slower than UMFPACK, 1.12s against 0.52s at n = 4,000, about what you would expect from a supernodal
+algorithm handed a matrix with no supernodes to find. The default polyalgorithm exists so you
+don't have to make this call yourself.
 
-| n | `LUFactorization` (UMFPACK) | `SupernodalLUFactorization` | `KLUFactorization` |
-|---|---|---|---|
-| 4,900 | 0.174 s | 0.019 s | 0.012 s |
-| 10,000 | 0.049 s | 0.047 s | 0.039 s |
-
-Relative residuals were ~1e-13 for all three. It is competitive on structured sparse problems — which is
-why the structured-sparse default LU now routes to it — though on an unstructured matrix with random
-fill I measured it slower than UMFPACK (1.12 s vs 0.52 s at n=4000). As always, the default polyalgorithm
-exists so you do not have to make this call yourself.
-
-The other notable addition is a genuinely new problem type: **`EigenvalueProblem`**, with
-`EigenvalueSolution` and `EigenvalueTarget`, backed by dense, Arpack, ArnoldiMethod, KrylovKit, and
-Jacobi–Davidson solvers. Eigenvalue computations now get the same swappable-algorithm treatment as linear
-and nonlinear solves:
+The other addition is a whole new problem type. `EigenvalueProblem`, with `EigenvalueSolution` and
+`EigenvalueTarget`, backed by dense, Arpack, ArnoldiMethod, KrylovKit and Jacobi–Davidson solvers, brings
+eigenvalue computations into the same swappable-algorithm world as linear and nonlinear solves:
 
 ```julia
 using LinearSolve, SciMLBase
 
 sol = solve(EigenvalueProblem([2.0 1.0; 1.0 3.0]))
-sol.u        # [3.618033988749895, 1.381966011250105]  — eigenvalues
+sol.u        # [3.618033988749895, 1.381966011250105]  eigenvalues
 sol.vectors  # eigenvectors
 sol.alg      # DenseEigen()
 sol.retcode  # Success
 ```
 
-Also in v5: lightweight solutions (`solve!` no longer populates `LinearSolution.cache`, which removes a
-large retention footprint), `warm_start` on `KrylovJL_GMRES`/`FGMRES`, BLAS LU workspace reuse across
-refactorizations, and automatic handling of nonstructural zeros.
+Also in v5: solutions got lighter, since `solve!` no longer populates `LinearSolution.cache` and so no
+longer retains a large chunk of memory you probably didn't want; `KrylovJL_GMRES` and `FGMRES` gained
+`warm_start`; BLAS LU workspaces are reused across refactorizations; and nonstructural zeros are handled
+automatically.
 
-**The caveat you need before you `Pkg.add`:** LinearSolve v5 is **not currently co-installable with
-OrdinaryDiffEq v7.1.3**. The ODE sublibraries (`OrdinaryDiffEqDefault`, `OrdinaryDiffEqDifferentiation`,
-`OrdinaryDiffEqNonlinearSolve`, `OrdinaryDiffEqRosenbrock`) cap LinearSolve at v4, so adding both gets you
-LinearSolve v4.3.0 and no `SupernodalLUFactorization`. If you want LinearSolve v5 features today, use it
-standalone; the compat bump is in progress, and the OrdinaryDiffEq change that makes Newton–Krylov
-integrators default to a Hegedüs warm start is already on `master` waiting on LinearSolve 5.1.
+For a short window this was harder to get at than it should have been: OrdinaryDiffEq v7.1.3 capped
+LinearSolve at v4, so asking for both quietly handed you v4.3.0 with no `SupernodalLUFactorization` in
+sight. OrdinaryDiffEq v7.2.0 lifted the cap. Adding `OrdinaryDiffEq` and `LinearSolve` together now
+resolves to LinearSolve v5.3.0 and the supernodal factorization is there.
 
-## Sensitivity analysis: implicit DAE adjoints
+That unblocked something else that had been waiting on it. Newton–Krylov integrators now default to a
+Hegedüs warm start, meaning a `KrylovJL` solver left on `WarmStart.Auto` gets resolved to
+`WarmStart.Hegedus` on the Newton path, which is the right mode for the sequence of correlated solves
+inside a Newton iteration. Rosenbrock and W-method integrators deliberately do not do this, since they
+have no outer Newton iteration to absorb the perturbation, so their `Auto` stays a cold start.
 
-SciMLSensitivity gained adjoint sensitivity support for **fully implicit `DAEProblem`s**, covering both
-index-1 and Hessenberg index-2 systems. Getting gradients through a fully implicit DAE has been a
-long-standing gap — you could differentiate mass-matrix ODEs, but genuinely implicit `f(du, u, p, t) = 0`
-formulations were not covered. If you are calibrating or optimizing a model expressed that way, this is
-the unlock.
+## Adjoints through fully implicit DAEs
 
-Alongside it: **`SundialsAdjoint`**, which uses the CVODES C adjoint interface directly rather than
-reimplementing it, and an `EnzymeVJP` dispatch for non-diagonal-noise SDE adjoints.
+SciMLSensitivity gained adjoint sensitivity support for fully implicit `DAEProblem`s, covering index-1
+and Hessenberg index-2 systems. This closes a gap that had been open a long time: you could already
+differentiate mass-matrix ODEs, but fully implicit `f(du, u, p, t) = 0` formulations weren't covered,
+which meant anyone whose model was naturally written that way had to reformulate it before they could
+calibrate or optimize anything. Alongside it there's `SundialsAdjoint`, driving the CVODES C adjoint
+interface directly instead of reimplementing it, and an `EnzymeVJP` dispatch for SDE adjoints with
+non-diagonal noise.
 
-## Compile time: `AutoDePSpecialize`
+## Compile time, again
 
-A new specialization level, `AutoDePSpecialize`, landed across SciMLBase, OrdinaryDiffEq, and
-NonlinearSolve. Where `AutoSpecialize` (the v7 default) reduces recompilation across right-hand side
-function types, `AutoDePSpecialize` goes after the *parameters*: it de-specializes non-`isbits` `p` via an
-`OpaqueRef`, so the solver does not recompile for every distinct parameter container type.
+`AutoDePSpecialize` is a new specialization level, landed across SciMLBase, OrdinaryDiffEq and
+NonlinearSolve. Where `AutoSpecialize`, the v7 default, cuts recompilation across right-hand side
+function types, this one goes after the parameters, de-specializing non-`isbits` `p` behind an
+`OpaqueRef` so the solver stops recompiling for every distinct parameter container type. It's aimed at
+large struct-of-arrays parameter objects and ModelingToolkit-generated containers, where you were
+otherwise paying a fresh compilation for each one. Opt-in.
 
-This is aimed at the case where you have a large struct-of-arrays parameter object, or a
-ModelingToolkit-generated parameter container, and you were paying a fresh compilation for it. It is
-opt-in.
+## The unglamorous half
 
-## The unglamorous half: allocations and step counts
+A good fraction of the merged work in this window adds no API at all. That makes it easy to leave out of
+a post like this. It is also where most of your day-to-day solve time comes from.
 
-A large fraction of the merged work in this window is performance grinding that produces no new API. It is
-worth listing because it is where day-to-day solve time actually comes from:
+ROCK2, ROCK4 and RKC now rotate their stage buffers instead of copying them in the in-place loops, and
+recompute the spectral radius every 25 steps by default instead of far more often. These are stabilized
+explicit methods, so they get used on the large problems where both of those were real costs.
+Rosenbrock stage accumulation loops were fused into single-sweep SIMD kernels. The EPIRK, Exp4 and
+EXPRB53s3 steppers had their per-step allocations removed and their residual column-slice updates turned
+into views. On the implicit side, redundant sparse-Jacobian structure rebuilds are skipped in `calc_J!`,
+W gets refactorized on the linear path when `γdt` drifts, and the SDIRK error estimate is smoothed by
+reusing the inner W factorization. `NonlinearSolveAlg` lost an inner termination check that could never
+fire, started surfacing inner failures instead of swallowing them, and now lets the integrator decide
+convergence instead of the inner solver.
 
-- **ROCK2 / ROCK4 / RKC**: stage buffers are now rotated instead of copied in the in-place loops, and the
-  spectral radius is recomputed every 25 steps by default rather than far more often. Stabilized explicit
-  methods are used precisely on large problems where both of those were real costs.
-- **Rosenbrock**: stage accumulation loops fused into single-sweep SIMD kernels.
-- **ExponentialRK**: per-step allocations removed from the EPIRK / Exp4 / EXPRB53s3 steppers, and residual
-  column-slice updates changed to views.
-- **Implicit solvers**: redundant sparse-Jacobian structure rebuilds skipped in `calc_J!`, W refactorized
-  on the linear path when `γdt` drifts, and the SDIRK error estimate smoothed by reusing the inner W
-  factorization.
-- **`NonlinearSolveAlg`**: an inner termination check that could never fire was removed, inner failures are
-  now surfaced instead of swallowed, and the integrator decides convergence rather than the inner solver.
+Structurally, `GlobalDiffEq.jl` moved into the OrdinaryDiffEq monorepo as `lib/GlobalDiffEq`, following
+`DiffEqBase`, for the same reason as before: packages that have to version in lockstep should release in
+lockstep.
 
-Also structural: `GlobalDiffEq.jl` moved into the OrdinaryDiffEq monorepo as `lib/GlobalDiffEq`, following
-`DiffEqBase`, on the same reasoning — packages that must version in lockstep should release in lockstep.
+## What to do with this
 
-## What to actually do with this
+If you're already on v7 and hitting DAE initialization failures or Newton convergence failures on stiff
+problems, the continuation work is aimed at you and a good deal of it is already wired in underneath. If
+you integrate DAEs to steady state, try `Rodas3d`. If you're solving structured sparse systems and would
+rather have fewer C dependencies, LinearSolve v5's supernodal LU, with the co-installability caveat
+above. If you're differentiating a fully implicit DAE, that works now. And if you have a real fast/slow
+split with an expensive slow term, the multirate family is worth benchmarking, with the emphasis on
+benchmarking.
 
-If you are on v7 already:
+One last thing, and it is really just the v7 advice continuing to pay off: depend on the specific
+sublibrary and not the umbrella. Beyond the load-time argument, `OrdinaryDiffEqRosenbrock` at v2.6.0
+had `Rodas3d` for a while before the `OrdinaryDiffEq` umbrella would resolve to it at all: v7.1.3 pinned
+it back to v2.4.2, and only v7.2.0 lets it through. Naming the sublibrary you need is how you get new
+solvers first.
 
-- **Hitting DAE initialization failures or Newton convergence failures on stiff problems?** The
-  continuation work is aimed directly at you, and much of it is already wired in underneath.
-- **Integrating DAEs to steady state?** Try `Rodas3d`.
-- **Solving structured sparse systems and want fewer C dependencies?** LinearSolve v5's
-  `SupernodalLUFactorization`, with the co-installability caveat above.
-- **Differentiating a fully implicit DAE?** That now works.
-- **Have a genuine fast/slow split with an expensive slow term?** The multirate family is worth
-  benchmarking — with emphasis on *benchmarking*.
-
-And the v7 advice that keeps paying off: depend on the specific sublibrary rather than the umbrella. Beyond
-the load-time win, `OrdinaryDiffEqRosenbrock` at v2.6.0 has `Rodas3d` while the `OrdinaryDiffEq` umbrella
-at v7.1.3 still resolves it to v2.4.2. Naming the sublibrary you need is how you get the newest solvers
-first.
-
-As always, the per-repo release notes are the exhaustive record, and questions are welcome on
+Per-repo release notes remain the exhaustive record, and questions are welcome on
 [the SciML Zulip](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged).


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Replaces #246, which I closed — SciMLBase 3.40 is going out today, so the "merged but not yet released" hedging there was pointless. This is everything in one PR.

Two independent things are in here.

## 1. The prose pass never landed on two of the three posts

Worth flagging because it was not obvious: #243 (MTK) merged on the 26th and #245 (since-v7) merged on the 27th, both **before** the "make it read less machine-written" work existed. Only #244 got it, because that one merged today. So master currently looks like this:

| post | em-dashes | bold label blocks | table rows |
|---|---|---|---|
| MTK v11 | 5 | 3 | 6 |
| ODE v7 | 0 | 0 | 28 |
| since v7 | 17 | 2 | 26 |

This PR brings the other two up to the same standard: em-dashes gone, `**Why:**` / `**What actually happened:**` label blocks gone, the four tables in the since-v7 post that were just restating sentences converted to prose, and the repeated constructions thinned (`", which …"` commentary clauses, `rather than`, `genuinely`, repeated `If you` openers). I checked that neither post picked up review edits during its merge, so the styled files are strictly the merged content plus the prose pass — no content is being reverted.

## 2. Four claims went stale, all verified before rewriting

**Controller kwargs.** SciMLBase 3.40 takes the eight names out of `allowedkeywords`, so the section moves to past tense and shows the error users now get. Verified against SciMLBase v3.40.1 + OrdinaryDiffEq v7.2.0: all eight throw `CommonKwargError` with the migration message, while plain solves, `controller = PIController(...)` and `failfactor` still work. I kept the section instead of deleting it — anyone pinned to 3.39 or earlier still gets the silent version, and nothing warns them.

**LinearSolve v5 co-installability.** The post said LinearSolve v5 *cannot* be installed alongside OrdinaryDiffEq, which is now backwards. OrdinaryDiffEq **7.2.0** lifted the v4 cap; `Pkg.add(["OrdinaryDiffEq","LinearSolve"])` now resolves LinearSolve **v5.3.0** with `SupernodalLUFactorization` present. Confirmed by installing it.

**Hegedüs warm start.** Described as "sitting on `master` waiting on LinearSolve 5.1". It shipped. `default_krylov_warm_start` in the released `OrdinaryDiffEqDifferentiation` resolves a `KrylovJL` solver on `WarmStart.Auto` to `WarmStart.Hegedus` on the Newton path, and deliberately leaves Rosenbrock/W-methods cold since they have no outer Newton iteration to absorb the perturbation. Written up properly rather than dropped.

**Rodas3d through the umbrella.** The closing advice used "7.1.3 resolves Rosenbrock back to v2.4.2" as its example. 7.2.0 resolves v2.6.0, so `Rodas3d` is reachable. Reworded to the past tense; the underlying advice (name the sublibrary) still holds, since the umbrella still doesn't re-export it.

## Verification

Re-ran all 10 snippet groups against OrdinaryDiffEq **7.2.0** rather than trusting the earlier 7.1.3 run — all pass. Robertson numbers unchanged (Rodas3d 1109 steps vs Rodas5P 193, constraint to 1.11e-16), and the `gamma` sweep still gives 5597 on 3.39.1 for the historical claim.

## Unrelated, but you may want to know

[JuliaRegistries/General#162635](https://github.com/JuliaRegistries/General/pull/162635) is still open, capping 16 packages at SciMLBase 3.39 over reexported names dropped in 3.40 (`isconstant`, `islinear`, `MatrixOperator`, `setproperties`, …). Not from #1471, which only touched the `allowedkeywords` tuple. OrdinaryDiffEq master already fixes forward in #4059.