### PR TITLE
Harden sciml.ai build: fail CI on Franklin errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - master
+  pull_request:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -22,13 +23,33 @@ jobs:
         version: '1.10'
     - name: Install rsync
       run: sudo apt-get update && sudo apt-get install --no-install-recommends -y rsync
-    - run: julia -e '
-            using Pkg; Pkg.add(["NodeJS", "Franklin"]);
-            using NodeJS; run(`$(npm_cmd()) install highlight.js`);
-            using Franklin;
-            Pkg.activate("."); Pkg.instantiate();
-            optimize()'
-    - name: Build and Deploy
+    - name: Build site
+      run: |
+        julia -e '
+          using Pkg
+          Pkg.add(["NodeJS", "Franklin"])
+          using NodeJS
+          run(`$(npm_cmd()) install highlight.js`)
+          using Franklin
+          Pkg.activate(".")
+          Pkg.instantiate()
+          optimize(; suppress_errors=false)
+          missing_pages = String[]
+          for (root, _, files) in walkdir("news")
+              for f in files
+                  endswith(f, ".md") || continue
+                  f == "index.md" && continue
+                  rel = first(splitext(relpath(joinpath(root, f), "news")))
+                  html = joinpath("__site", "news", rel, "index.html")
+                  isfile(html) || push!(missing_pages, html)
+              end
+          end
+          isempty(missing_pages) || error("Franklin did not write: $(join(missing_pages, ", "))")
+          news = read(joinpath("__site", "news", "index.html"), String)
+          occursin("/news/2016/11/26/hello/", news) || error("news index has no posts")
+        '
+    - name: Deploy
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/gsoc/gsoc_symbolic_numeric.md
+++ b/gsoc/gsoc_symbolic_numeric.md
@@ -151,6 +151,7 @@ Catalyst.jl provides the ability to create symbolic models of chemical reaction 
 - [ADVANCED LEVEL] spatial model representations in Catalyst combined with code generation for PDE libraries (such as Ferrite).
 - [MODERATE LEVEL] new ModelingToolkit-based systems to represent τ-leaping and/or abstract master equation representations, along with translation layers to generate such systems from Catalyst reaction network models.
 - [ADVANCED/MODERATE LEVEL] support for delays in ODE/SDE models and their propagation through ModelingToolkitBase to generate concrete models.
+@@
 
 **Recommended Skills**: Very strong understanding of ODE models for chemical systems and Julia open-source programming
 particularly [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) and [ModelingToolkit.jl](https://github.com/SciML/ModelingToolkit.jl). Abstract algebra and graph theory for the network analysis components. Stochastic chemical kinetics and Gillespie method experience for the τ-leaping projects. 

--- a/news/2025/10/10/SymbolicIntegration.md
+++ b/news/2025/10/10/SymbolicIntegration.md
@@ -232,7 +232,7 @@ Albert Rich's comprehensive RUBI rule-based integration system.
 
 If you use SymbolicIntegration.jl in your research, please cite:
 
-```bibtex
+```plaintext
 @software{SymbolicIntegration.jl,
   author = {Harald Hofstätter and Mattia Micheletta Merlin and Chris Rackauckas},
   title = {SymbolicIntegration.jl: Symbolic Integration for Julia},


### PR DESCRIPTION
**Please ignore this PR until it is reviewed by @ChrisRackauckas.**

Depends on https://github.com/SciML/sciml.ai/pull/251 (merged).

The outage on https://sciml.ai/news/ happened because Franklin's `optimize()` defaults to `suppress_errors=true`. A parse error in one post became a warning, `{{blogposts}}` produced an empty grid, and the site still deployed.

This PR does **not** swallow those errors. It makes the build fail:

- `optimize(; suppress_errors=false)` so a Franklin parse error fails the job instead of warning and continuing.
- After the build, every `news/**/*.md` post must have generated HTML, and the news index must still list posts.
- Run that build on pull requests. Deploy still only runs on push to master/main.

Also fixes two pages that would now fail that check: close the leftover `@@tight-list` in `gsoc/gsoc_symbolic_numeric.md`, and highlight the SymbolicIntegration citation as `plaintext` (highlight.js has no `bibtex`).

There is no try/catch around `pagevar`. A bad post fails the build.

## Verification

Franklin v0.10.97, current tree vs the pre-#251 MTK post:

```
unfixed=OCBlockError
fixed=ok
```

`optimize(; suppress_errors=false)` on this branch completed and the news index still contains `/news/2016/11/26/hello/`.

## What this PR did not verify

- GitHub Pages after merge. #251 already deployed the live fix.

🤖 Generated with Grok Build TUI (model: grok-4.6)
Agent-Session: local session 01a085b6-fb4c-7e42-8d24-379d1868a3b0 (no shareable URL)